### PR TITLE
CEP-440 - Eligible contacts are not re-added to engagement campaigns

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -582,7 +582,7 @@ class LeadRepository extends CommonRepository
     {
         $membershipConditions = [
             $qb->expr()->eq('cl.lead_id', 'll.lead_id'),
-            $qb->expr()->eq('cl.campaign_id', (int) $campaignId)
+            $qb->expr()->eq('cl.campaign_id', (int) $campaignId),
         ];
 
         if ($campaignCanBeRestarted) {

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -405,9 +405,9 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
+        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
-            $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
         }
 
@@ -440,9 +440,9 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
+        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
-            $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
         }
 
@@ -578,16 +578,22 @@ class LeadRepository extends CommonRepository
      * @param              $campaignId
      * @param QueryBuilder $qb
      */
-    private function updateQueryWithExistingMembershipExclusion($campaignId, QueryBuilder $qb)
+    private function updateQueryWithExistingMembershipExclusion($campaignId, QueryBuilder $qb, $campaignCanBeRestarted = false)
     {
+        $membershipConditions = [
+            $qb->expr()->eq('cl.lead_id', 'll.lead_id'),
+            $qb->expr()->eq('cl.campaign_id', (int) $campaignId)
+        ];
+
+        if ($campaignCanBeRestarted) {
+            $membershipConditions[] = $qb->expr()->eq('cl.manually_removed', 0);
+        }
+
         $subq = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
             ->where(
-                $qb->expr()->andX(
-                    $qb->expr()->eq('cl.lead_id', 'll.lead_id'),
-                    $qb->expr()->eq('cl.campaign_id', (int) $campaignId)
-                )
+                $qb->expr()->andX(...$membershipConditions)
             );
 
         $qb->andWhere(

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -405,9 +405,9 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
-        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
 
         if (!$campaignCanBeRestarted) {
+            $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
         }
 
@@ -440,9 +440,9 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
-        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
 
         if (!$campaignCanBeRestarted) {
+            $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb);
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
         }
 


### PR DESCRIPTION
[Jira Issue](https://medullan.atlassian.net/browse/CEP-440)

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | 
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #7338
| BC breaks? | 
| Deprecations? | 

[//]: # ( Required: )
#### Description:

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a contact with the tag `campaign-member`

2. Create a dynamic segment called `campaign-members`, where the filter includes the tag campaign-member

3. Create a campaign called `test-campaign`:
   - Set the "Allow contacts to restart the campaign" option to yes
   - Set the "Published" option to yes
   - Use the `campaign-members` segment as the contact source. 
   - Add a campaign action to modify the contact tags and remove the `campaign-member` tag

4. Execute the following commands:

     ```bash
      php app/console mautic:segement:update
      php app/console mautic:campaign:rebuild
      php app/console mautic:campaign:trigger
      ```

     The contact should have been added to the segment, then the campaign, the campaign should have removed the campaign-member tag.

5. Execute the following commands:

     ```bash
      php app/console mautic:segement:update
      php app/console mautic:campaign:rebuild
      ```

     The contact should be removed from the segment and the campaign.

6. Add the `campaign-member` tag to the contact

7. Re-run step 4.The contact is added to the `campaign-members` segment but is not added to the campaign, thus still has the `campaign-member` tag.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com/7704/s/login)
2. Execute "Steps to reproduce the bug" above
3. Observe that the contact was re-added to the campaign and the campaign should remove the campaign-member tag.