### PR TITLE
Cep 667 contacts stuck in campaign

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -175,6 +175,7 @@ return [
                     'mautic.channel.model.queue',
                     'mautic.email.model.send_email_to_user',
                     'translator',
+                    'mautic.factory',
                 ],
             ],
             'mautic.email.campaignbundle.condition_subscriber' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -175,7 +175,7 @@ return [
                     'mautic.channel.model.queue',
                     'mautic.email.model.send_email_to_user',
                     'translator',
-                    'mautic.factory',
+                    'monolog.logger.mautic',
                 ],
             ],
             'mautic.email.campaignbundle.condition_subscriber' => [

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -31,7 +31,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Mautic\CoreBundle\Factory\MauticFactory;
+use Monolog\Logger;
 
 /**
  * Class CampaignSubscriber.
@@ -69,9 +69,9 @@ class CampaignSubscriber implements EventSubscriberInterface
     private $translator;
 
     /**
-     * @var MauticFactory
+     * @var Logger
      */
-    protected $factory;
+    private $logger;
 
     /**
      * @param LeadModel         $leadModel
@@ -87,7 +87,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         MessageQueueModel $messageQueueModel,
         SendEmailToUser $sendEmailToUser,
         TranslatorInterface $translator,
-        MauticFactory $factory
+        Logger $logger
     ) {
         $this->leadModel          = $leadModel;
         $this->emailModel         = $emailModel;
@@ -95,7 +95,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $this->messageQueueModel  = $messageQueueModel;
         $this->sendEmailToUser    = $sendEmailToUser;
         $this->translator         = $translator;
-        $this->factory            = $factory;
+        $this->logger             = $logger;
     }
 
     /**
@@ -378,7 +378,7 @@ class CampaignSubscriber implements EventSubscriberInterface
                     // log must be removed from credentialArray so that it is not passed to both fail() and pass() functions
                     unset($credentialArray[$log->getId()]);
 
-                    $this->factory->getLogger()->log('error', '[MAIL-SEND-EVENT ERROR] '.$e->getMessage());
+                    $this->logger->error('[MAIL-SEND-EVENT ERROR] '.$e->getMessage());
                     continue;
                 }
             }

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -371,7 +371,7 @@ class CampaignSubscriber implements EventSubscriberInterface
                         continue;
                     }
 
-                    $event->fail($log, $reason);
+                $event->fail($log, $reason);
                 } catch (\Exception $e) {
                     $event->fail($log, $reason);
 

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -358,7 +358,7 @@ class CampaignSubscriber implements EventSubscriberInterface
 
         if (count($credentialArray)) {
             $errors = $this->emailModel->sendEmail($email, $credentialArray, $options);
-            
+
             // Fail those that failed to send
             foreach ($errors as $failedContactId => $reason) {
                 try {
@@ -371,7 +371,7 @@ class CampaignSubscriber implements EventSubscriberInterface
                         continue;
                     }
 
-                $event->fail($log, $reason);
+                    $event->fail($log, $reason);
                 } catch (\Exception $e) {
                     $event->fail($log, $reason);
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1482,7 +1482,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $this->sendModel->finalFlush();
 
         // Get the errors to return
-        $errorMessages  = array_merge($errors, $this->sendModel->getErrors());
+        $errorMessages  = $errors + $this->sendModel->getErrors();
         $failedContacts = $this->sendModel->getFailedContacts();
 
         // Get sent counts to update email stats

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1482,6 +1482,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $this->sendModel->finalFlush();
 
         // Get the errors to return
+        // use + operator to preserve numeric key indexes
         $errorMessages  = $errors + $this->sendModel->getErrors();
         $failedContacts = $this->sendModel->getFailedContacts();
 

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -21,6 +21,7 @@ use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Translation\TranslatorInterface;
+use Mautic\CoreBundle\Factory\MauticFactory;
 
 class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -61,8 +62,12 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator);
+        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
+        
         $args = [
             'lead'  => 64,
             'event' => [
@@ -107,8 +112,12 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator);
+        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
+        
         $args = [
             'lead'  => $lead,
             'event' => [
@@ -160,7 +169,11 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator);
+        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
 
         $args = [
             'lead'  => $lead,

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -21,7 +21,7 @@ use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Translation\TranslatorInterface;
-use Mautic\CoreBundle\Factory\MauticFactory;
+use Monolog\Logger;
 
 class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,11 +62,11 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+        $mockLogger = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockLogger);
         
         $args = [
             'lead'  => 64,
@@ -112,12 +112,12 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+        $mockLogger = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
-        
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockLogger);
+
         $args = [
             'lead'  => $lead,
             'event' => [
@@ -169,11 +169,11 @@ class CampaignSubscriberTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockMauticFactory = $this->getMockBuilder(MauticFactory::class)
+        $mockLogger = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockMauticFactory);
+        $subscriber = new CampaignSubscriber($mockLeadModel, $mockEmailModel, $mockEventModel, $mockMessageQueueModel, $mockSendEmailToUser, $mockTranslator, $mockLogger);
 
         $args = [
             'lead'  => $lead,


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | None
| Related developer documentation PR URL | https://docs.google.com/document/d/1uOfmCzHLxmAUqK7Rg2X-5JlZTkhKNKB4sWSvHAKXiZM/edit?usp=sharing
| Issues addressed (#s or URLs) | See developer documentation
| BC breaks? | No
| Deprecations? | No

#### Description
This PR implements our fix for contacts getting stuck in a campaign due to email-send failure